### PR TITLE
updating bands, adding NEW-MUSIC

### DIFF
--- a/maria/band/configs/atlast.yml
+++ b/maria/band/configs/atlast.yml
@@ -107,4 +107,3 @@ f850:
   gain_error: 5.e-2
   NEP: 3.e-17 # W / sqrt(s)
   knee: 1.0 # Hz
-

--- a/maria/band/configs/atlast.yml
+++ b/maria/band/configs/atlast.yml
@@ -1,6 +1,6 @@
 f027:
   center: 27.e+9
-  width: 5.e+9
+  width: 18.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -10,7 +10,17 @@ f027:
 
 f039:
   center: 39.e+9
-  width: 5.e+9
+  width: 13.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f042:
+  center: 42.e+9
+  width: 24.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -19,8 +29,8 @@ f039:
   knee: 1.0 # Hz
 
 f093:
-  center: 93.e+9
-  width: 10.e+9
+  center: 91.5e+9
+  width: 51.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -29,8 +39,8 @@ f093:
   knee: 1.0 # Hz
 
 f150:
-  center: 150.e+9
-  width: 10.e+9
+  center: 151.e+9
+  width: 62.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -39,8 +49,8 @@ f150:
   knee: 1.0 # Hz
 
 f220:
-  center: 220.e+9
-  width: 30.e+9
+  center: 217.5e+9
+  width: 69.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -49,8 +59,8 @@ f220:
   knee: 1.0 # Hz
 
 f280:
-  center: 280.e+9
-  width: 40.e+9
+  center: 288.5e+9
+  width: 73.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -60,7 +70,7 @@ f280:
 
 f350:
   center: 350.e+9
-  width: 34.e+9
+  width: 50.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
@@ -69,11 +79,32 @@ f350:
   knee: 1.0 # Hz
 
 f400:
-  center: 400.e+9
-  width: 30.e+9
+  center: 403.e+9
+  width: 38.e+9
   shape: top_hat
   time_constant: 0
   efficiency: 0.5
   gain_error: 5.e-2
   NEP: 3.e-17 # W / sqrt(s)
   knee: 1.0 # Hz
+
+f650:
+  center: 654.e+9
+  width: 118.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f850:
+  center: 845.5e+9
+  width: 119.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+

--- a/maria/band/configs/music.yml
+++ b/maria/band/configs/music.yml
@@ -1,0 +1,54 @@
+b1:
+    center: 90.e9,  # in Hz
+    width: 35.e9,  # in Hz
+    NET_RJ: 40.e-6,  # in K sqrt(s)
+    knee: 1.0,    # in Hz
+    shape: top_hat,
+    efficiency: 0.5,
+    gain_error: 5.e-2
+
+b2 :
+    center: 150.e9,
+    width: 47.e9,
+    NET_RJ: 60.e-6,
+    knee: 1.0,
+    shape: top_hat,
+    efficiency: 0.5,
+    gain_error: 5.e-2
+
+b3 :
+    center: 230.e9,
+    width: 45.e9,
+    NET_RJ: 100.e-6,
+    knee: 1.0,
+    shape: top_hat,
+    efficiency: 0.5,
+    gain_error: 5.e-2
+
+b4 :
+    center: 275.e9,
+    width: 40.e9,
+    NET_RJ: 100.e-6,
+    knee: 1.0,
+    shape: top_hat,
+    efficiency: 0.5,
+    gain_error: 5.e-2
+
+b5 :
+    center: 350.e9,
+    width: 34.e9,
+    NET_RJ: 300.e-6,
+    knee: 1.0,
+    shape: top_hat,
+    efficiency: 0.5,
+    gain_error: 5.e-2
+
+b6 :
+    center: 400.e9,
+    width: 30.e9,
+    NET_RJ: 400.e-6,
+    knee: 1.0,
+    shape: top_hat,
+    efficiency: 0.5,
+    gain_error: 5.e-2
+

--- a/maria/band/configs/music.yml
+++ b/maria/band/configs/music.yml
@@ -1,54 +1,54 @@
 b1:
-    center: 90.e9,  # in Hz
-    width: 35.e9,  # in Hz
-    NET_RJ: 40.e-6,  # in K sqrt(s)
-    knee: 1.0,    # in Hz
-    shape: top_hat,
-    efficiency: 0.5,
+    center: 90.e+9  # in Hz
+    width: 35.e+9  # in Hz
+    NET_RJ: 40.e-6  # in K sqrt(s)
+    knee: 1.0    # in Hz
+    shape: top_hat
+    efficiency: 0.5
     gain_error: 5.e-2
 
-b2 :
-    center: 150.e9,
-    width: 47.e9,
-    NET_RJ: 60.e-6,
-    knee: 1.0,
-    shape: top_hat,
-    efficiency: 0.5,
+b2:
+    center: 150.e+9
+    width: 47.e+9
+    NET_RJ: 60.e-6
+    knee: 1.0
+    shape: top_hat
+    efficiency: 0.5
     gain_error: 5.e-2
 
-b3 :
-    center: 230.e9,
-    width: 45.e9,
-    NET_RJ: 100.e-6,
-    knee: 1.0,
-    shape: top_hat,
-    efficiency: 0.5,
+b3:
+    center: 230.e+9
+    width: 45.e+9
+    NET_RJ: 100.e-6
+    knee: 1.0
+    shape: top_hat
+    efficiency: 0.5
     gain_error: 5.e-2
 
-b4 :
-    center: 275.e9,
-    width: 40.e9,
-    NET_RJ: 100.e-6,
-    knee: 1.0,
-    shape: top_hat,
-    efficiency: 0.5,
+b4:
+    center: 275.e+9
+    width: 40.e+9
+    NET_RJ: 100.e-6
+    knee: 1.0
+    shape: top_hat
+    efficiency: 0.5
     gain_error: 5.e-2
 
-b5 :
-    center: 350.e9,
-    width: 34.e9,
-    NET_RJ: 300.e-6,
-    knee: 1.0,
-    shape: top_hat,
-    efficiency: 0.5,
+b5:
+    center: 350.e+9
+    width: 34.e+9
+    NET_RJ: 300.e-6
+    knee: 1.0
+    shape: top_hat
+    efficiency: 0.5
     gain_error: 5.e-2
 
-b6 :
-    center: 400.e9,
-    width: 30.e9,
-    NET_RJ: 400.e-6,
-    knee: 1.0,
-    shape: top_hat,
-    efficiency: 0.5,
+b6:
+    center: 400.e+9
+    width: 30.e+9
+    NET_RJ: 400.e-6
+    knee: 1.0
+    shape: top_hat
+    efficiency: 0.5
     gain_error: 5.e-2
 

--- a/maria/band/configs/music.yml
+++ b/maria/band/configs/music.yml
@@ -51,4 +51,3 @@ b6:
     shape: top_hat
     efficiency: 0.5
     gain_error: 5.e-2
-

--- a/maria/band/configs/so.yml
+++ b/maria/band/configs/so.yml
@@ -1,0 +1,69 @@
+f027:
+  center: 27.e+9
+  width: 18.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f039:
+  center: 39.e+9
+  width: 13.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f093:
+  center: 93.e+9
+  width: 27.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f150:
+  center: 145.e+9
+  width: 41.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f220:
+  center: 225.e+9
+  width: 58.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f280:
+  center: 280.e+9
+  width: 57.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz
+
+f350:
+  center: 350.e+9
+  width: 50.e+9
+  shape: top_hat
+  time_constant: 0
+  efficiency: 0.5
+  gain_error: 5.e-2
+  NEP: 3.e-17 # W / sqrt(s)
+  knee: 1.0 # Hz

--- a/maria/instrument/configs/music.yml
+++ b/maria/instrument/configs/music.yml
@@ -1,11 +1,11 @@
 NEW-MUSIC:
-  aliases: ["new-music"]
-  description: NEW-MUSIC
+  aliases: ["music"]
+  description: MUSIC
   arrays:
     array-1:
       n: 16
       shape: square
-      bands: [atlast/f093]
+      bands: [music/b1]
       polarized: False
       bath_temp: 100.e-3 # in K
       field_of_view: 0.117 # in degrees
@@ -13,7 +13,7 @@ NEW-MUSIC:
     array-2:
       n: 16
       shape: square
-      bands: [atlast/f150]
+      bands: [music/b2]
       polarized: False
       bath_temp: 100.e-3 # in K
       field_of_view: 0.117 # in degrees
@@ -21,7 +21,7 @@ NEW-MUSIC:
     array-3:
       n: 64
       shape: square
-      bands: [atlast/f220]
+      bands: [music/b3]
       polarized: False
       bath_temp: 100.e-3 # in K
       field_of_view: 0.117 # in degrees
@@ -29,7 +29,7 @@ NEW-MUSIC:
     array-4:
       n: 64
       shape: square
-      bands: [atlast/f280]
+      bands: [music/b4]
       polarized: False
       bath_temp: 100.e-3 # in K
       field_of_view: 0.117 # in degrees
@@ -37,7 +37,7 @@ NEW-MUSIC:
     array-5:
       n: 256
       shape: square
-      bands: [atlast/f350]
+      bands: [music/b5]
       polarized: False
       bath_temp: 100.e-3 # in K
       field_of_view: 0.117 # in degrees
@@ -45,7 +45,7 @@ NEW-MUSIC:
     array-6:
       n: 256
       shape: square
-      bands: [atlast/f400]
+      bands: [music/b6]
       polarized: False
       bath_temp: 100.e-3 # in K
       field_of_view: 0.117 # in degrees

--- a/maria/instrument/configs/newmusic.yml
+++ b/maria/instrument/configs/newmusic.yml
@@ -1,0 +1,52 @@
+NEW-MUSIC:
+  aliases: ["new-music"]
+  description: NEW-MUSIC
+  arrays:
+    array-1:
+      n: 64
+      shape: square
+      bands: [music/b1]
+      polarized: False
+      bath_temp: 100.e-3 # in K
+      field_of_view: 0.234 # in degrees
+      primary_size: 10.4 # in meters
+    array-2:
+      n: 64
+      shape: square
+      bands: [music/b2]
+      polarized: False
+      bath_temp: 100.e-3 # in K
+      field_of_view: 0.234 # in degrees
+      primary_size: 10.4 # in meters
+    array-3:
+      n: 256
+      shape: square
+      bands: [music/b3]
+      polarized: False
+      bath_temp: 100.e-3 # in K
+      field_of_view: 0.234 # in degrees
+      primary_size: 10.4 # in meters
+    array-4:
+      n: 256
+      shape: square
+      bands: [music/b4]
+      polarized: False
+      bath_temp: 100.e-3 # in K
+      field_of_view: 0.234 # in degrees
+      primary_size: 10.4 # in meters
+    array-5:
+      n: 1024
+      shape: square
+      bands: [music/b5]
+      polarized: False
+      bath_temp: 100.e-3 # in K
+      field_of_view: 0.234 # in degrees
+      primary_size: 10.4 # in meters
+    array-6:
+      n: 1024
+      shape: square
+      bands: [music/b6]
+      polarized: False
+      bath_temp: 100.e-3 # in K
+      field_of_view: 0.234 # in degrees
+      primary_size: 10.4 # in meters


### PR DESCRIPTION
I've updated the SO and AtLAST band definitions to match the updated SO LAT (https://ui.adsabs.harvard.edu/abs/2025JCAP...08..034A/abstract) and the AtLAST SZ science cases (https://ui.adsabs.harvard.edu/abs/2025ORE.....4..113D/abstract) respectively.  I've also added the MUSIC bands from Golwala et al. 2024 (https://ui.adsabs.harvard.edu/abs/2024SPIE13102E..02G/abstract) and the 1/4 and full array versions of MUSIC/NEW-MUSIC.